### PR TITLE
Switch ui-editor  component color on drag and hover

### DIFF
--- a/src/utils/ui-editor.js
+++ b/src/utils/ui-editor.js
@@ -26,6 +26,7 @@ function createUIEditor(paper, options) {
 	resetHandle.children[1].transformContent = false;
 
 	distributionHandle.onMouseDrag = function(event) {
+		distributionHandle.fillColor = '#f3e04a';
 		var expandVect = UIEditor.selection.expandedTo[0].point.subtract(UIEditor.selection.expandedTo[1].point);
 		var direction = new paper.Point(
 			Math.cos(UIEditor.selection.expand.angle),
@@ -53,6 +54,7 @@ function createUIEditor(paper, options) {
 
 	distributionHandle.onMouseUp = function(event) {
 		UIEditor.onConfirmChanges();
+		distributionHandle.fillColor = '#24d390';
 	}
 
 	var directionHandle = new paper.Path.Arc({
@@ -75,6 +77,7 @@ function createUIEditor(paper, options) {
 	};
 
 	directionHandle.onMouseDrag = function(event) {
+		directionHandle.strokeColor = '#f3e04a';
 		var transformedEventPoint = new paper.Point(event.point.x, -event.point.y);
 		var skewedSelection = new paper.Point(
 			UIEditor.selection.x + UIEditor.selection.path.viewMatrix.c / paper.view.zoom  * UIEditor.selection.y,
@@ -106,10 +109,39 @@ function createUIEditor(paper, options) {
 
 	directionHandle.onMouseUp = function(event) {
 		UIEditor.onConfirmChanges();
+		directionHandle.strokeColor = '#24d390';
 	}
 
 	resetHandle.onClick = function() {
 		UIEditor.onResetCursor(UIEditor.selection.contourIdx, UIEditor.selection.nodeIdx);
+		resetHandle.children[0].fillColor = '#f3e04a';
+		setTimeout(function() {
+			resetHandle.children[0].fillColor = '#24d390';
+		}, 100);
+	}
+
+	directionHandle.onMouseEnter = function() {
+		directionHandle.strokeColor = '#f3e04a';
+	}
+
+	resetHandle.onMouseEnter = function() {
+		resetHandle.children[0].fillColor = '#f3e04a';
+	}
+
+	distributionHandle.onMouseEnter = function() {
+		distributionHandle.fillColor = '#f3e04a';
+	}
+
+	directionHandle.onMouseLeave = function() {
+		directionHandle.strokeColor = '#24d390';
+	}
+
+	resetHandle.onMouseLeave = function() {
+		resetHandle.children[0].fillColor = '#24d390';
+	}
+
+	distributionHandle.onMouseLeave = function() {
+		distributionHandle.fillColor = '#24d390';
 	}
 
 	UIEditor.remove = function() {


### PR DESCRIPTION
![md3fnaiu0l](https://cloud.githubusercontent.com/assets/5655615/21725447/be9b27d4-d438-11e6-9da5-a2babf9398bd.gif)
This changes were picked from feat/manualHover because they were quite easy to make regarding the state of prototypo-canvas. The rest is on hold for now.
